### PR TITLE
Default to config.prepareBaseImage if no param specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -312,8 +312,11 @@ class ResembleHelper extends Helper {
       options.prepareBaseImage = true;
     }
 
+    const prepareBaseImage = options.prepareBaseImage !== undefined
+      ? options.prepareBaseImage
+      : this.config.prepareBaseImage
     const awsC = this.config.aws;
-    if (awsC !== undefined && options.prepareBaseImage === false) {
+    if (awsC !== undefined && prepareBaseImage === false) {
       await this._download(awsC.accessKeyId, awsC.secretAccessKey, awsC.region, awsC.bucketName, baseImage);
     }
     if (options.prepareBaseImage !== undefined && options.prepareBaseImage) {

--- a/index.js
+++ b/index.js
@@ -308,13 +308,9 @@ class ResembleHelper extends Helper {
       options.tolerance = 0;
     }
 
-    if (this.prepareBaseImage) {
-      options.prepareBaseImage = true;
-    }
-
     const prepareBaseImage = options.prepareBaseImage !== undefined
       ? options.prepareBaseImage
-      : this.config.prepareBaseImage
+      : (this.prepareBaseImage === true)
     const awsC = this.config.aws;
     if (awsC !== undefined && prepareBaseImage === false) {
       await this._download(awsC.accessKeyId, awsC.secretAccessKey, awsC.region, awsC.bucketName, baseImage);


### PR DESCRIPTION
We are only downloading the base image if the `options` param explicitly includes the option `{prepareBaseImage: false}`. Otherwise, it will omit downloading the base file, even if the helper configuration includes the prepareBaseImage option.

This change allows us to default to the value in the config file if the method doesn't receive that param.