### PR TITLE
fix: fix global prepareBaseImage

### DIFF
--- a/index.js
+++ b/index.js
@@ -311,11 +311,12 @@ class ResembleHelper extends Helper {
     const prepareBaseImage = options.prepareBaseImage !== undefined
       ? options.prepareBaseImage
       : (this.prepareBaseImage === true)
+
     const awsC = this.config.aws;
     if (awsC !== undefined && prepareBaseImage === false) {
       await this._download(awsC.accessKeyId, awsC.secretAccessKey, awsC.region, awsC.bucketName, baseImage);
     }
-    if (options.prepareBaseImage !== undefined && options.prepareBaseImage) {
+    if (prepareBaseImage) {
       await this._prepareBaseImage(baseImage);
     }
     if (selector) {


### PR DESCRIPTION
After [this change](https://github.com/codeceptjs/codeceptjs-resemblehelper/pull/79), the global `prepareBaseImage` is not generating the base images. It's only working when passing to `seeVisualDiff`.

Fixes https://github.com/codeceptjs/codeceptjs-resemblehelper/issues/88