### PR TITLE
New option `compareWithImage` to compare a screenshot with a custom file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To use the Helper, users may provide the parameters:
 
 `prepareBaseImage`: Optional. When `true` then the system replaces all of the baselines related to the test case(s) you ran. This is equivalent of setting the option `prepareBaseImage: true` in all verifications of the test file.
 
+`compareWithImage`: Optional. A custom filename to compare the screenshot with. The `compareWithImage` file must be located inside the `baseFolder`.
 
 ### Usage
 
@@ -182,6 +183,21 @@ This base image has to be located inside a folder named "*base*".
 The resultant output image will be uploaded in a folder named "*output*" and diff image will be uploaded to a folder named "*diff*" in the S3 bucket.
 If the `prepareBaseImage` option is marked `true`, then the generated base image will be uploaded to a folder named "*base*" in the S3 bucket.
 > Note: The tests may take a bit longer to run when the AWS configuration is provided as determined by the internet speed to upload/download images.
+
+### Compare with custom image
+Usually, every screenshot needs to have the same filename as an existing image inside the `baseFolder` directory. To change this behavior, you can use the `compareWithImage` option and specify a different image inside the `baseFolder` directory:
+```js
+I.seeVisualDiffForElement("#element", "image.png", {compareWithImage: "login-screen.png"});
+```
+This is useful, if you want to compare a single screenshot against multiple base images - for example, when you want to validate that the main menu element is identical on all app pages.
+
+Or, in some cases there are intended visual differences for different browsers or operating systems:
+```js
+const os = "win32" === process.platform ? "win" : "mac";
+
+// Compare "image.png" either with "image-win.png" or "image-mac.png":
+I.seeVisualDiff("image.png", {compareWithImage: `image-${os}.png`});
+```
 
 ### Known Issues:
 

--- a/README.md
+++ b/README.md
@@ -185,11 +185,13 @@ If the `prepareBaseImage` option is marked `true`, then the generated base image
 > Note: The tests may take a bit longer to run when the AWS configuration is provided as determined by the internet speed to upload/download images.
 
 ### Compare with custom image
-Usually, every screenshot needs to have the same filename as an existing image inside the `baseFolder` directory. To change this behavior, you can use the `compareWithImage` option and specify a different image inside the `baseFolder` directory:
-```js
-I.seeVisualDiffForElement("#element", "image.png", {compareWithImage: "login-screen.png"});
-```
+Usually, every screenshot needs to have the same filename as an existing image inside the `baseFolder` directory. To change this behavior, you can use the `compareWithImage` option and specify a different image inside the `baseFolder` directory.
+
 This is useful, if you want to compare a single screenshot against multiple base images - for example, when you want to validate that the main menu element is identical on all app pages.
+```js
+I.seeVisualDiffForElement("#element", "image.png", {compareWithImage: "dashboard.png"});
+I.seeVisualDiffForElement("#element", "image.png", {compareWithImage: "account.png"});
+```
 
 Or, in some cases there are intended visual differences for different browsers or operating systems:
 ```js

--- a/index.js
+++ b/index.js
@@ -38,8 +38,8 @@ class ResembleHelper extends Helper {
    */
   async _compareImages(image, options) {
     const baseImage = this._getBaseImagePath(image, options);
-    const actualImage = this._getActualImagePath(image, options);
-    const diffImage = this._getDiffImagePath(image, options);
+    const actualImage = this._getActualImagePath(image);
+    const diffImage = this._getDiffImagePath(image);
 
     // check whether the base and the screenshot images are present.
     fs.access(baseImage, fs.constants.F_OK | fs.constants.R_OK, (err) => {
@@ -152,8 +152,8 @@ class ResembleHelper extends Helper {
 
     if (allure !== undefined && misMatch >= options.tolerance) {
       allure.addAttachment('Base Image', fs.readFileSync(this._getBaseImagePath(baseImage, options)), 'image/png');
-      allure.addAttachment('Screenshot Image', fs.readFileSync(this._getActualImagePath(baseImage, options)), 'image/png');
-      allure.addAttachment('Diff Image', fs.readFileSync(this._getDiffImagePath(baseImage, options)), 'image/png');
+      allure.addAttachment('Screenshot Image', fs.readFileSync(this._getActualImagePath(baseImage)), 'image/png');
+      allure.addAttachment('Diff Image', fs.readFileSync(this._getDiffImagePath(baseImage)), 'image/png');
     }
   }
 
@@ -172,9 +172,9 @@ class ResembleHelper extends Helper {
       await mocha.addMochawesomeContext("Base Image");
       await mocha.addMochawesomeContext(this._getBaseImagePath(baseImage, options));
       await mocha.addMochawesomeContext("ScreenShot Image");
-      await mocha.addMochawesomeContext(this._getActualImagePath(baseImage, options));
+      await mocha.addMochawesomeContext(this._getActualImagePath(baseImage));
       await mocha.addMochawesomeContext("Diff Image");
-      await mocha.addMochawesomeContext(this._getDiffImagePath(baseImage, options));
+      await mocha.addMochawesomeContext(this._getDiffImagePath(baseImage));
     }
   }
 
@@ -197,7 +197,7 @@ class ResembleHelper extends Helper {
       secretAccessKey: secretAccessKey,
       region: region
     });
-    fs.readFile(this._getActualImagePath(baseImage, options), (err, data) => {
+    fs.readFile(this._getActualImagePath(baseImage), (err, data) => {
       if (err) throw err;
       let base64data = new Buffer(data, 'binary');
       const params = {
@@ -210,7 +210,7 @@ class ResembleHelper extends Helper {
         console.log(`Screenshot Image uploaded successfully at ${uData.Location}`);
       });
     });
-    fs.readFile(this._getDiffImagePath(baseImage, options), (err, data) => {
+    fs.readFile(this._getDiffImagePath(baseImage), (err, data) => {
       if (err) console.log("Diff image not generated");
       else {
         let base64data = new Buffer(data, 'binary');
@@ -226,8 +226,8 @@ class ResembleHelper extends Helper {
       }
     });
 
-	// If prepareBaseImage is false, then it won't upload the baseImage. However, this parameter is not considered if the config file has a prepareBaseImage set to true.
-	if (options.prepareBaseImage) {
+    // If prepareBaseImage is false, then it won't upload the baseImage. However, this parameter is not considered if the config file has a prepareBaseImage set to true.
+    if (options.prepareBaseImage) {
       const baseImageName = this._getbaseImageName(baseImage, options);
 
       fs.readFile(this._getBaseImagePath(baseImage, options), (err, data) => {
@@ -346,7 +346,7 @@ class ResembleHelper extends Helper {
    */
   async _prepareBaseImage(screenShotImage, options) {
   	const baseImage = this._getBaseImagePath(screenShotImage, options);
-  	const actualImage = this._getActualImagePath(screenShotImage, options);
+  	const actualImage = this._getActualImagePath(screenShotImage);
 
     await this._createDir(baseImage);
 
@@ -499,6 +499,5 @@ class ResembleHelper extends Helper {
   	return this.diffFolder + diffImage;
   }
 }
-
 
 module.exports = ResembleHelper;


### PR DESCRIPTION
A new and optional option value that allows to compare a screenshot to a base-image with a different file name.

Reasons for this:
1. If you want to compare a single screenshot against multiple base images - for example, when you want to validate that the main menu element is identical on all app pages.
2. If parts of an image contain intended visual differences for different browsers or operating systems.
3. Possibly, there are even more other use-cases