### PR TITLE
Updated packages so that it runs on M1 mac (Node v16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   },
   "dependencies": {
     "assert": "^1.5.0",
-    "canvas": "2.8.0",
-    "mz": "2.7.0",
-    "resemblejs": "4.0.0",
-    "mkdirp": "^1.0.4",
-    "path": "^0.12.7",
     "aws-sdk": "2.1027.0",
-    "image-size": "1.0.0"
+    "canvas": "^2.8.0",
+    "image-size": "1.0.0",
+    "mkdirp": "^1.0.4",
+    "mz": "2.7.0",
+    "path": "^0.12.7",
+    "resemblejs": "4.0.0"
   },
   "devDependencies": {
     "allure-commandline": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   },
   "dependencies": {
     "assert": "^1.5.0",
-    "canvas": "^2.6.1",
-    "mz": "^2.7.0",
-    "resemblejs": "^3.2.4",
+    "canvas": "2.8.0",
+    "mz": "2.7.0",
+    "resemblejs": "4.0.0",
     "mkdirp": "^1.0.4",
     "path": "^0.12.7",
-    "aws-sdk": "^2.662.0",
-    "image-size": "^0.8.3"
+    "aws-sdk": "2.1027.0",
+    "image-size": "1.0.0"
   },
   "devDependencies": {
     "allure-commandline": "^2.13.0",


### PR DESCRIPTION
Issue: https://github.com/codeceptjs/codeceptjs-resemblehelper/issues/87

Issue was caused by node-canvas package which was fixed on node-canvas v2.8.0 https://github.com/Automattic/node-canvas/blob/master/CHANGELOG.md

This PR fixed the error.