### PR TITLE
[REGRESSION] renamed method to _resolveRelativePath, but called old name

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,11 +191,11 @@ class ResembleHelper extends Helper {
 
     if (mocha !== undefined && misMatch >= options.tolerance) {
       await mocha.addMochawesomeContext("Base Image");
-      await mocha.addMochawesomeContext(this.resolveImagePathRelativeFromReport(this._getBaseImagePath(baseImage, options)));
+      await mocha.addMochawesomeContext(this._resolveRelativePath(this._getBaseImagePath(baseImage, options)));
       await mocha.addMochawesomeContext("ScreenShot Image");
-      await mocha.addMochawesomeContext(this.resolveImagePathRelativeFromReport(this._getActualImagePath(baseImage)));
+      await mocha.addMochawesomeContext(this._resolveRelativePath(this._getActualImagePath(baseImage)));
       await mocha.addMochawesomeContext("Diff Image");
-      await mocha.addMochawesomeContext(this.resolveImagePathRelativeFromReport(this._getDiffImagePath(baseImage)));
+      await mocha.addMochawesomeContext(this._resolveRelativePath(this._getDiffImagePath(baseImage)));
     }
   }
 


### PR DESCRIPTION
regression introduced to last-minute changes before 1.9.5 release: renamed method, but not method calls