### PR TITLE
Fixed "this.resolveImagePathRelativeFromReport is not a function"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ declare class ResembleHelper {
     screenshotFolder: string;
     prepareBaseImage: any;
     resolvePath(folderPath: any): any;
+    _resolveRelativePath(folderPath: any): any;
     /**
      * Compare Images
      *
@@ -17,7 +18,7 @@ declare class ResembleHelper {
      * @param options
      * @returns {Promise<resolve | reject>}
      */
-    _compareImages(image: any, options: any): Promise<any | any>;
+    _compareImages(image: any, options: any): Promise<resolve | reject>;
     /**
      *
      * @param image

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ class ResembleHelper extends Helper {
       absolutePathOfReportFolder = Container.mocha().options.reporterOptions.reportDir;
     }
     // support mocha-multi-reporters
-    if (Container.mocha() && typeof Container.mocha().options.reporterOptions.mochawesomeReporterOptions.reportDir !== 'undefined') {
+    if (Container.mocha() && typeof Container.mocha().options.reporterOptions.mochawesomeReporterOptions?.reportDir !== 'undefined') {
       absolutePathOfReportFolder = Container.mocha().options.reporterOptions.mochawesomeReporterOptions.reportDir;
     }
     return path.relative(absolutePathOfReportFolder, absolutePathOfImage);
@@ -191,11 +191,11 @@ class ResembleHelper extends Helper {
 
     if (mocha !== undefined && misMatch >= options.tolerance) {
       await mocha.addMochawesomeContext("Base Image");
-      await mocha.addMochawesomeContext(this.resolveImagePathRelativeFromReport(this._getBaseImagePath(baseImage, options)));
+      await mocha.addMochawesomeContext(this._resolveRelativePath(this._getBaseImagePath(baseImage, options)));
       await mocha.addMochawesomeContext("ScreenShot Image");
-      await mocha.addMochawesomeContext(this.resolveImagePathRelativeFromReport(this._getActualImagePath(baseImage)));
+      await mocha.addMochawesomeContext(this._resolveRelativePath(this._getActualImagePath(baseImage)));
       await mocha.addMochawesomeContext("Diff Image");
-      await mocha.addMochawesomeContext(this.resolveImagePathRelativeFromReport(this._getDiffImagePath(baseImage)));
+      await mocha.addMochawesomeContext(this._resolveRelativePath(this._getDiffImagePath(baseImage)));
     }
   }
 
@@ -344,8 +344,8 @@ class ResembleHelper extends Helper {
       options.boundingBox = await this._getBoundingBox(selector);
     }
     const misMatch = await this._fetchMisMatchPercentage(baseImage, options);
-    this._addAttachment(baseImage, misMatch, options);
-    this._addMochaContext(baseImage, misMatch, options);
+    await this._addAttachment(baseImage, misMatch, options);
+    await this._addMochaContext(baseImage, misMatch, options);
     if (awsC !== undefined) {
       await this._upload(awsC.accessKeyId, awsC.secretAccessKey, awsC.region, awsC.bucketName, baseImage, options)
     }


### PR DESCRIPTION
**Motivation:** Fixes #102 
* Fixed "this.resolveImagePathRelativeFromReport is not a function" caused by fix of #95
  * @jpmschuler could you test if your method `_resolveRelativePath` works as expected? I only checked that my tests pass and they are able to catch screenshot difference (failure) as with previous versions
* Fixed UnhandledPromiseRejectionWarning (missing awaits) - it's not caused by #95, but that bug discovered the "unhandled promise" issue
* Updated TS definition using `npx -p typescript tsc index.js --declaration --allowJs --emitDeclarationOnly`