### PR TITLE
Fix empty output settings sent in Resemble options

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ class ResembleHelper extends Helper {
 
     return new Promise((resolve, reject) => {
 
-      if (options.outputSettings) {
+      if (!options.outputSettings) {
         options.outputSettings = {};
       }
       if (typeof options.needsSameDimension === 'undefined') {


### PR DESCRIPTION
### Context
This small one fixes the issue resemble.js Output Settings not working.

https://github.com/codeceptjs/codeceptjs-resemblehelper/issues/118

### Cause
outputSettings object become empty when sent in parameters.

### Fix
Change the condition.

