### PR TITLE
correct image sequence on comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ class ResembleHelper extends Helper {
       this.debug("Tolerance Level Provided " + options.tolerance);
       const tolerance = options.tolerance;
 
-      resemble.compare(baseImage, actualImage, options, (err, data) => {
+      resemble.compare(actualImage, baseImage, options, (err, data) => {
         if (err) {
           reject(err);
         } else {


### PR DESCRIPTION
### Context
The output setting `ignoreAreasColoredWith` must use the colored areas in the base image to correctly apply the ignored areas to the actual image. 
#122 

### Cause
Base und actual image are inverted when comparing images.

### Fix
Switch the order of the images. The parameter `image1` must be the `actualImage` and `image2` must be the `baseImage`.
